### PR TITLE
docs : Modify Dockerfile not to run pytest and flake8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,15 @@ RUN apt-get update \
     && apt-get install -y python3 python3-pip
 
 # install dependency
-RUN python3 -m pip install --upgrade pip \
-    && pip install flake8 pytest
+RUN python3 -m pip install --upgrade pip
+    # && pip install flake8 pytest
 
-# lint with flake8
-RUN flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-RUN flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+# # lint with flake8
+# RUN flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+# RUN flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 # Test with pytest
-RUN python3 -m pytest tests
+# RUN python3 -m pytest tests
 
 # start app.py
 CMD ["python3", "./src/app.py"]


### PR DESCRIPTION
## Modify Dockerfile not to run pytest and flake8

개요:
도커 파일에 lint와 pytest 목적의 명령어를 삭제하여 빌드 시간을 줄이고자 함

## 작업 내용 (필수)
- flake8, pytest 실행 명령어 삭제

## 관련 이슈 (선택사항)
(관련된 이슈가 있다면 여기에 링크를 제공해주세요)

## 추가 정보 (선택사항)
(추가적으로 알아야 할 사항이 있다면 여기에 기입해주세요)
